### PR TITLE
ci: enable cron job to trigger each day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 on: [pull_request]
+  workflow_dispatch:
+  schedule:
+   - cron: '0 1 * * *' # every day 1:00 AM
 jobs:
   os-compatibility:
     strategy:


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a cron job to the CI that is triggered every day at 1:00 AM.

The reason why we want this job is because we want to catch regressions every time we do a release.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge and see it gets triggered at the time mentioned

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
